### PR TITLE
biplaR-pdf: add engine lualatex

### DIFF
--- a/inst/extdata/_extensions/biplaR-pdf/template.qmd
+++ b/inst/extdata/_extensions/biplaR-pdf/template.qmd
@@ -12,6 +12,7 @@ lang: de
 
 format:
     pdf:
+        pdf-engine: lualatex
         include-in-header:
         - _extensions/biplaR-pdf/preamble.tex
         template: _extensions/biplaR-pdf/tmplt.tex


### PR DESCRIPTION
add pdf-engine lualatex to template for biplaR-pdf in order to render the template with TinyTeX on the DAP (closes #59 )